### PR TITLE
Refactor Dockerfiles

### DIFF
--- a/{{cookiecutter.repo_name}}/docker/{{cookiecutter.repo_name}}-model-training-gpu.Dockerfile
+++ b/{{cookiecutter.repo_name}}/docker/{{cookiecutter.repo_name}}-model-training-gpu.Dockerfile
@@ -1,0 +1,58 @@
+FROM nvcr.io/nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
+
+ARG DEBIAN_FRONTEND="noninteractive"
+
+ARG NON_ROOT_USER="aisg"
+ARG NON_ROOT_UID="2222"
+ARG NON_ROOT_GID="2222"
+ARG HOME_DIR="/home/${NON_ROOT_USER}"
+
+ARG REPO_DIR="."
+ARG CONDA_ENV_FILE="{{cookiecutter.repo_name}}-conda-env.yaml"
+ARG CONDA_ENV_NAME="{{cookiecutter.repo_name}}"
+
+# Miniconda arguments
+ARG CONDA_HOME="/miniconda3"
+ARG CONDA_BIN="${CONDA_HOME}/bin/conda"
+ARG CONDA_VER="py310_23.5.2-0"
+ARG CONDA_ARCH="Linux-x86_64"
+ARG MINICONDA_SH="Miniconda3-${CONDA_VER}-${CONDA_ARCH}.sh"
+
+RUN useradd -l -m -s /bin/bash -u ${NON_ROOT_UID} ${NON_ROOT_USER} && \
+    mkdir -p ${CONDA_HOME} && \
+    chown -R ${NON_ROOT_USER}:${NON_ROOT_GID} ${CONDA_HOME}
+
+RUN apt-get update && \
+    apt-get -y install bzip2 curl wget gcc rsync git vim locales && \
+    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8 && \
+    apt-get clean
+
+ENV PYTHONIOENCODING utf8
+ENV LANG "C.UTF-8"
+ENV LC_ALL "C.UTF-8"
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+ENV LD_LIBRARY_PATH /usr/local/cuda/lib64:$LD_LIBRARY_PATH
+
+USER ${NON_ROOT_USER}
+WORKDIR ${HOME_DIR}
+
+# Install Miniconda
+RUN curl -O https://repo.anaconda.com/miniconda/${MINICONDA_SH} && \
+    chmod +x ${MINICONDA_SH} && \
+    ./${MINICONDA_SH} -u -b -p ${CONDA_HOME} && \
+    rm ${MINICONDA_SH}
+ENV PATH ${CONDA_HOME}/bin:${HOME_DIR}/.local/bin:$PATH 
+
+COPY --chown=${NON_ROOT_USER}:${NON_ROOT_GID} ${CONDA_ENV_FILE} {{cookiecutter.repo_name}}/${CONDA_ENV_FILE}
+
+# Install conda environment
+RUN ${CONDA_BIN} env create -f {{cookiecutter.repo_name}}/${CONDA_ENV_FILE} && \
+    ${CONDA_BIN} init bash && \
+    ${CONDA_BIN} clean -a -y && \
+    echo "source activate ${CONDA_ENV_NAME}" >> "${HOME_DIR}/.bashrc"
+
+COPY --chown=${NON_ROOT_USER}:${NON_ROOT_GID} ${REPO_DIR} {{cookiecutter.repo_name}}

--- a/{{cookiecutter.repo_name}}/docker/{{cookiecutter.repo_name}}-model-training.Dockerfile
+++ b/{{cookiecutter.repo_name}}/docker/{{cookiecutter.repo_name}}-model-training.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/cuda:11.3.0-cudnn8-devel-ubuntu18.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND="noninteractive"
 
@@ -22,8 +22,6 @@ RUN useradd -l -m -s /bin/bash -u ${NON_ROOT_UID} ${NON_ROOT_USER} && \
     mkdir -p ${CONDA_HOME} && \
     chown -R ${NON_ROOT_USER}:${NON_ROOT_GID} ${CONDA_HOME}
 
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
-
 RUN apt-get update && \
     apt-get -y install bzip2 curl wget gcc rsync git vim locales && \
     sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
@@ -35,14 +33,9 @@ RUN apt-get update && \
 ENV PYTHONIOENCODING utf8
 ENV LANG "C.UTF-8"
 ENV LC_ALL "C.UTF-8"
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
-ENV LD_LIBRARY_PATH /usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
 USER ${NON_ROOT_USER}
 WORKDIR ${HOME_DIR}
-
-COPY --chown=${NON_ROOT_USER}:${NON_ROOT_GID} ${REPO_DIR} {{cookiecutter.repo_name}}
 
 # Install Miniconda
 RUN curl -O https://repo.anaconda.com/miniconda/${MINICONDA_SH} && \
@@ -50,8 +43,13 @@ RUN curl -O https://repo.anaconda.com/miniconda/${MINICONDA_SH} && \
     ./${MINICONDA_SH} -u -b -p ${CONDA_HOME} && \
     rm ${MINICONDA_SH}
 ENV PATH ${CONDA_HOME}/bin:${HOME_DIR}/.local/bin:$PATH
+
+COPY --chown=${NON_ROOT_USER}:${NON_ROOT_GID} ${CONDA_ENV_FILE} {{cookiecutter.repo_name}}/${CONDA_ENV_FILE}
+
 # Install conda environment
 RUN ${CONDA_BIN} env create -f {{cookiecutter.repo_name}}/${CONDA_ENV_FILE} && \
     ${CONDA_BIN} init bash && \
     ${CONDA_BIN} clean -a -y && \
     echo "source activate ${CONDA_ENV_NAME}" >> "${HOME_DIR}/.bashrc"
+
+COPY --chown=${NON_ROOT_USER}:${NON_ROOT_GID} ${REPO_DIR} {{cookiecutter.repo_name}}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-conda-env.yaml
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-conda-env.yaml
@@ -1,17 +1,20 @@
 name: {{cookiecutter.repo_name}}
 channels:
   - defaults
+  - pytorch
   - conda-forge
 dependencies:
   - python=3.10.11
+  ## remove cpuonly for use with GPU
+  - cpuonly=2.0
+  - pytorch=2.0.1
+  - torchvision=0.15.2
+  - torchdata=0.6.1
   - pip=23.1.2
   - pip:
     - python-json-logger==2.0.7
     - pytest==7.4.0
     - pandas==2.0.3
-    - torch==2.0.1
-    - torchdata==0.6.1
-    - torchvision==0.15.2
     - hydra-core==1.3.2
     - hydra-optuna-sweeper==1.2.0
     - pre-commit==3.3.3


### PR DESCRIPTION
Scope:
- removed GPU elements from the `model-training.Dockerfile`
- reduced `data-prep` and `model-training` images to 3.7GB from 8.9GB, by virtue of simpler base `ubuntu:20.04` image and by specifying non-gpu requirement `cpuonly=2.0` in `conda.yml`
- added a `model-training-gpu.Dockerfile` as an example for GPU workloads
